### PR TITLE
fix: add muxer negotiation timeouts and migrate to PEP 735 dependency

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
   tox:
     runs-on: ubuntu-latest
-    timeout-minutes: 60  # 1 hour timeout
+    timeout-minutes: 60 # 1 hour timeout
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
@@ -73,7 +73,7 @@ jobs:
         if: matrix.toxenv == 'interop'
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: "22"
 
       - run: |
           uv venv venv
@@ -104,7 +104,7 @@ jobs:
   webrtc-serial:
     name: WebRTC Transport Tests (Serial)
     runs-on: ubuntu-latest
-    timeout-minutes: 60  # 1 hour timeout
+    timeout-minutes: 60 # 1 hour timeout
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
@@ -123,8 +123,7 @@ jobs:
           uv venv venv
           source venv/bin/activate
           uv pip install --upgrade pip
-          uv pip install -e ".[dev,webrtc]"
-          uv pip install pytest pytest-trio pytest-timeout
+          uv pip install --group dev -e .
       - name: Run WebRTC tests serially
         run: |
           source venv/bin/activate
@@ -132,7 +131,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    timeout-minutes: 60  # 1 hour timeout
+    timeout-minutes: 60 # 1 hour timeout
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
@@ -158,8 +157,9 @@ jobs:
         shell: bash
         run: |
           source venv/Scripts/activate
+          PYVER=$(echo "${{ matrix.python-version }}" | tr -d '.')
           if [[ "${{ matrix.toxenv }}" == "wheel" ]]; then
             python -m tox run -e windows-wheel
           else
-            python -m tox run -e py${{ matrix.python-version }}-${{ matrix.toxenv }}
+            python -m tox run -e "py${PYVER}-${{ matrix.toxenv }}"
           fi

--- a/libp2p/transport/webrtc/connection.py
+++ b/libp2p/transport/webrtc/connection.py
@@ -1017,9 +1017,7 @@ class WebRTCRawConnection(IRawConnection):
                     with trio.move_on_after(MUXER_READ_TIMEOUT) as read_scope:
                         data = await self.receive_channel.receive()
                     if read_scope.cancelled_caught:
-                        ch_state = getattr(
-                            self.data_channel, "readyState", "unknown"
-                        )
+                        ch_state = getattr(self.data_channel, "readyState", "unknown")
                         conn_state = getattr(
                             self.peer_connection, "connectionState", "unknown"
                         )
@@ -1033,8 +1031,7 @@ class WebRTCRawConnection(IRawConnection):
                             conn_state,
                         )
                         raise trio.TooSlowError(
-                            f"WebRTC read timed out after "
-                            f"{MUXER_READ_TIMEOUT}s"
+                            f"WebRTC read timed out after {MUXER_READ_TIMEOUT}s"
                         )
                     self._read_buffer = data
                 except trio.TooSlowError:

--- a/libp2p/transport/webrtc/connection.py
+++ b/libp2p/transport/webrtc/connection.py
@@ -20,6 +20,7 @@ from libp2p.custom_types import TProtocol
 from libp2p.peer.id import ID
 
 from .async_bridge import WebRTCAsyncBridge
+from .constants import MUXER_READ_TIMEOUT
 
 logger = logging.getLogger("libp2p.transport.webrtc.connection")
 
@@ -640,15 +641,22 @@ class WebRTCRawConnection(IRawConnection):
                         f"🔵 FIRST MESSAGE CONSUMED from buffer for {self.peer_id}"
                     )
 
-                # Process via unified pipeline
+                # Deliver to send_channel for read() to consume.
+                # Note: dedup/JSON-muxing is handled in on_data_channel_message
+                # path; data pump just forwards raw bytes from the inbound channel.
                 try:
-                    if hasattr(self, "_process_inbound_payload"):
-                        self._process_inbound_payload(data)
-                    else:
-                        # Direct delivery if processor not initialized
-                        self.send_channel.send_nowait(data)
+                    self.send_channel.send_nowait(data)
+                except trio.WouldBlock:
+                    logger.warning(
+                        "send_channel full in data pump for %s - "
+                        "potential backpressure during muxer negotiation",
+                        self.peer_id,
+                    )
+                except trio.ClosedResourceError:
+                    logger.debug("send_channel closed in data pump")
+                    break
                 except Exception as proc_err:
-                    logger.error(f"Error processing buffered message: {proc_err}")
+                    logger.error(f"Error delivering buffered message: {proc_err}")
         except Exception as e:
             if not self._closed:
                 logger.error(
@@ -954,8 +962,32 @@ class WebRTCRawConnection(IRawConnection):
                 if not self._read_buffer:
                     try:
                         logger.debug("MUXER read wait (n=None) peer=%s", self.peer_id)
-                        data = await self.receive_channel.receive()
+                        with trio.move_on_after(MUXER_READ_TIMEOUT) as read_scope:
+                            data = await self.receive_channel.receive()
+                        if read_scope.cancelled_caught:
+                            ch_state = getattr(
+                                self.data_channel, "readyState", "unknown"
+                            )
+                            conn_state = getattr(
+                                self.peer_connection, "connectionState", "unknown"
+                            )
+                            logger.error(
+                                "read() timed out after %.1fs for %s "
+                                "(channel=%s, conn=%s) - "
+                                "data pipeline may be stalled",
+                                MUXER_READ_TIMEOUT,
+                                self.peer_id,
+                                ch_state,
+                                conn_state,
+                            )
+                            raise trio.TooSlowError(
+                                f"WebRTC read timed out after "
+                                f"{MUXER_READ_TIMEOUT}s "
+                                f"(channel={ch_state}, conn={conn_state})"
+                            )
                         self._read_buffer = data
+                    except trio.TooSlowError:
+                        raise
                     except trio.ClosedResourceError:
                         self._closed = True
                         return b""
@@ -982,8 +1014,31 @@ class WebRTCRawConnection(IRawConnection):
             if not self._read_buffer:
                 try:
                     logger.debug("MUXER read wait n=%s peer=%s", n, self.peer_id)
-                    data = await self.receive_channel.receive()
+                    with trio.move_on_after(MUXER_READ_TIMEOUT) as read_scope:
+                        data = await self.receive_channel.receive()
+                    if read_scope.cancelled_caught:
+                        ch_state = getattr(
+                            self.data_channel, "readyState", "unknown"
+                        )
+                        conn_state = getattr(
+                            self.peer_connection, "connectionState", "unknown"
+                        )
+                        logger.error(
+                            "read(n=%s) timed out after %.1fs for %s "
+                            "(channel=%s, conn=%s)",
+                            n,
+                            MUXER_READ_TIMEOUT,
+                            self.peer_id,
+                            ch_state,
+                            conn_state,
+                        )
+                        raise trio.TooSlowError(
+                            f"WebRTC read timed out after "
+                            f"{MUXER_READ_TIMEOUT}s"
+                        )
                     self._read_buffer = data
+                except trio.TooSlowError:
+                    raise
                 except trio.ClosedResourceError:
                     self._closed = True
                     return b""

--- a/libp2p/transport/webrtc/constants.py
+++ b/libp2p/transport/webrtc/constants.py
@@ -114,6 +114,8 @@ DEFAULT_HANDSHAKE_TIMEOUT = 40.0  # seconds
 DEFAULT_ICE_GATHERING_TIMEOUT = 10.0  # seconds
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_DELAY = 1.0  # seconds
+MUXER_NEGOTIATE_TIMEOUT = 45.0  # seconds - dedicated muxer negotiation timeout
+MUXER_READ_TIMEOUT = 30.0  # seconds - per-read timeout during muxer negotiation
 
 # Buffer sizes
 DEFAULT_STREAM_BUFFER_SIZE = 64 * 1024  # 64KB

--- a/libp2p/transport/webrtc/private_to_public/connect.py
+++ b/libp2p/transport/webrtc/private_to_public/connect.py
@@ -1777,28 +1777,10 @@ async def connect(
                     f"{role} Noise handshake completed, upgrade protection active"
                 )
 
-                # Validate secure_conn.write() uses real DataChannel
-                # (Noise wired to raw).
-                logger.debug(
-                    f"{role} Validating secure_conn.write() uses real DataChannel..."
+                logger.info(
+                    "%s Noise handshake completed - stream ready for muxer negotiation",
+                    role,
                 )
-                try:
-                    test_ping = b"PING\n"
-                    await secure_conn.write(test_ping)
-                    logger.info(
-                        "%s secure_conn.write() OK - transport validation passed",
-                        role,
-                    )
-                except Exception as write_test_exc:
-                    logger.error(
-                        f"❌ {role} secure_conn.write() FAILED: {write_test_exc}",
-                        exc_info=True,
-                    )
-                    # This indicates Noise is not properly wired to the DataChannel
-                    raise RuntimeError(
-                        "Transport validation failed: secure_conn.write() %s"
-                        % write_test_exc
-                    ) from write_test_exc
             except Exception as handshake_error:
                 # Mark handshake as no longer in progress
                 raw_connection._handshake_in_progress = False

--- a/libp2p/transport/webrtc/private_to_public/transport.py
+++ b/libp2p/transport/webrtc/private_to_public/transport.py
@@ -1100,23 +1100,16 @@ class WebRTCDirectTransport(ITransport):
                     type(muxed_conn).__name__,
                 )
 
-                if isinstance(muxed_conn, Yamux):
-                    logger.info(
-                        "🟢 Starting listener yamux read loop for %s",
-                        remote_peer_id,
-                    )
-                    try:
-                        await muxed_conn.start()
-                        logger.info(
-                            "✅ Listener yamux read loop started for %s", remote_peer_id
-                        )
-                    except Exception as start_exc:
-                        logger.error(
-                            "❌ Failed to start listener yamux for %s: %s",
-                            remote_peer_id,
-                            start_exc,
-                            exc_info=True,
-                        )
+                logger.info(
+                    "🟢 Listener registering muxed conn with swarm for %s",
+                    remote_peer_id,
+                )
+                await swarm.add_conn(muxed_conn)
+                logger.info(
+                    "✅ Listener swarm.add_conn() completed for %s - "
+                    "stream accept loop is now running",
+                    remote_peer_id,
+                )
             except trio.TooSlowError:
                 logger.error(
                     "Listener muxer negotiation timed out after %.1fs "

--- a/libp2p/transport/webrtc/private_to_public/transport.py
+++ b/libp2p/transport/webrtc/private_to_public/transport.py
@@ -15,7 +15,6 @@ from libp2p.abc import IHost, IListener, IRawConnection, ISecureConn, ITransport
 from libp2p.custom_types import THandler
 from libp2p.peer.id import ID
 from libp2p.relay.circuit_v2.nat import ReachabilityChecker
-from libp2p.stream_muxer.yamux.yamux import Yamux
 from libp2p.transport.exceptions import OpenConnectionError
 
 from ..async_bridge import get_webrtc_bridge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dev = [
     "aiortc>=1.14.0",
     "trio-asyncio>=0.15.0",
     "factory-boy>=2.12.0,<3.0.0",
-    "p2pclient==0.2.0",
+    "p2pclient>=0.2.1",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-timeout>=2.4.0",
@@ -125,6 +125,55 @@ dev = [
     "pre-commit>=3.4.0",
     "tox>=4.0.0",
     "redis>=5.0.0",
+    "twine",
+    "wheel",
+    "setuptools>=42",
+    "ruff>=0.11.10",
+    "pyrefly (>=0.17.1,<0.18.0)",
+]
+
+[dependency-groups]
+test = [
+    "factory-boy>=2.12.0,<3.0.0",
+    "p2pclient>=0.2.1",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-timeout>=2.4.0",
+    "pytest-trio>=0.5.2",
+    "pytest-xdist>=2.4.0",
+    "pytest-mock>=3.15.1",
+    "pytest-rerunfailures>=12.0",
+]
+webrtc = [
+    "aiortc>=1.14.0",
+    "trio-asyncio>=0.15.0",
+    "redis>=5.0.0",
+]
+docs = [
+    "sphinx>=6.0.0",
+    "sphinx_rtd_theme>=1.0.0",
+    "towncrier>=25,<26",
+    "tomli; python_version < '3.11'",
+    "aiortc>=1.14.0",
+    "trio-asyncio>=0.15.0",
+]
+release = [
+    "build>=0.9.0",
+    "bump_my_version>=0.19.0",
+    "setuptools>=42",
+    "twine",
+    "wheel",
+]
+dev = [
+    {include-group = "test"},
+    {include-group = "webrtc"},
+    {include-group = "docs"},
+    "build>=0.9.0",
+    "bump_my_version>=0.19.0",
+    "ipython",
+    "mypy>=1.15.0",
+    "pre-commit>=3.4.0",
+    "tox>=4.0.0",
     "twine",
     "wheel",
     "setuptools>=42",

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,9 @@ allowlist_externals=
 
 [testenv:py{310,311,312,313}-lint]
 deps=pre-commit
+commands_pre=
+    uv pip install --upgrade pip
+    uv pip install --group dev -e .
 setenv =
     PYTHONPATH={envsitepackagesdir}{:}{env:PYTHONPATH:}
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ per-file-ignores=__init__.py:F401
 usedevelop=True
 commands_pre=
     uv pip install --upgrade pip
-    uv pip install -e ".[test,docs,webrtc]"
+    uv pip install --group test --group docs --group webrtc -e .
 commands=
     core: pytest -n auto --timeout=1200 {posargs:tests/core}
     demos: pytest -n auto --timeout=1200 {posargs:tests/examples}


### PR DESCRIPTION
fix: add muxer negotiation timeouts and migrate to PEP 735 dependency groups

- Add timeout protection to MultiselectClient.handshake() write/read ops
- Add outer trio.fail_after() to query_multistream_command()
- Add MUXER_NEGOTIATE_TIMEOUT (45s) and MUXER_READ_TIMEOUT (30s) constants
- Add per-read timeout in WebRTCRawConnection.read()
- Wrap dialer + listener upgrade_connection() with muxer timeout
- Fix _data_pump_task broken hasattr check for _process_inbound_payload
- Increase buffer consumer wait from 2s to 5s under load
- Add PEP 735 [dependency-groups] to pyproject.toml
- Migrate tox.ini to uv pip install --group syntax
- Fix Windows CI tox env names (strip dots from python version)
- Use --group dev for webrtc-serial CI job, remove redundant installs